### PR TITLE
Devtools

### DIFF
--- a/devtools.js
+++ b/devtools.js
@@ -33,7 +33,11 @@ yargs(hideBin(process.argv))
 
                 console.log((await parseDoc(doc)).md)
             } catch (e) {
-                console.error(e)
+                if (e.code === 404) {
+                    console.error("Invalid doc ID")
+                } else {
+                    console.error(e)
+                }
             }
         }
     )

--- a/devtools.js
+++ b/devtools.js
@@ -1,47 +1,52 @@
-import yargs from "yargs"
-import { hideBin } from "yargs/helpers"
+import yargs from "yargs";
+import { hideBin } from "yargs/helpers";
 
 import { getDocsClient } from "./parser/gdrive.js";
-import { parseDoc } from "./parser/parser.js"
-
+import { parseDoc } from "./parser/parser.js";
 
 yargs(hideBin(process.argv))
-    .usage('Usage: $0 <command> [options]')
-    .command(
-        'json <googleDocID>',
-        'Get the JSON for an answer doc',
-        async ({argv: {_: [_, documentId]}}) => {
-            try {
-                const docs = await getDocsClient()
-                const doc = (await docs.documents.get({ documentId })).data
-    
-                console.log(JSON.stringify(doc, null, 2))
-            } catch (e) {
-                if (e.code === 404) {
-                    console.error("Invalid doc ID")
-                }
-            }
-        }
-    )
-    .command(
-        'md <googleDocID>',
-        'Get the rendered Markdown for an answer doc',
-        async ({argv: {_: [_, documentId]}}) => {
-            try {
-                const docs = await getDocsClient()
-                const doc = (await docs.documents.get({ documentId })).data
+  .usage("Usage: $0 <command> [options]")
+  .command(
+    "json <googleDocID>",
+    "Get the JSON for an answer doc",
+    async ({
+      argv: {
+        _: [_, documentId],
+      },
+    }) => {
+      try {
+        const docs = await getDocsClient();
+        const doc = (await docs.documents.get({ documentId })).data;
 
-                console.log((await parseDoc(doc)).md)
-            } catch (e) {
-                if (e.code === 404) {
-                    console.error("Invalid doc ID")
-                } else {
-                    console.error(e)
-                }
-            }
+        console.log(JSON.stringify(doc, null, 2));
+      } catch (e) {
+        if (e.code === 404) {
+          console.error("Invalid doc ID");
         }
-    )
-    .help('h')
-    .alias('h', 'help')
-    .argv
+      }
+    }
+  )
+  .command(
+    "md <googleDocID>",
+    "Get the rendered Markdown for an answer doc",
+    async ({
+      argv: {
+        _: [_, documentId],
+      },
+    }) => {
+      try {
+        const docs = await getDocsClient();
+        const doc = (await docs.documents.get({ documentId })).data;
 
+        console.log((await parseDoc(doc)).md);
+      } catch (e) {
+        if (e.code === 404) {
+          console.error("Invalid doc ID");
+        } else {
+          console.error(e);
+        }
+      }
+    }
+  )
+  .help("h")
+  .alias("h", "help").argv;

--- a/devtools.js
+++ b/devtools.js
@@ -1,0 +1,43 @@
+import yargs from "yargs"
+import { hideBin } from "yargs/helpers"
+
+import { getDocsClient } from "./parser/gdrive.js";
+import { parseDoc } from "./parser/parser.js"
+
+
+yargs(hideBin(process.argv))
+    .usage('Usage: $0 <command> [options]')
+    .command(
+        'json <googleDocID>',
+        'Get the JSON for an answer doc',
+        async ({argv: {_: [_, documentId]}}) => {
+            try {
+                const docs = await getDocsClient()
+                const doc = (await docs.documents.get({ documentId })).data
+    
+                console.log(JSON.stringify(doc, null, 2))
+            } catch (e) {
+                if (e.code === 404) {
+                    console.error("Invalid doc ID")
+                }
+            }
+        }
+    )
+    .command(
+        'md <googleDocID>',
+        'Get the rendered Markdown for an answer doc',
+        async ({argv: {_: [_, documentId]}}) => {
+            try {
+                const docs = await getDocsClient()
+                const doc = (await docs.documents.get({ documentId })).data
+
+                console.log((await parseDoc(doc)).md)
+            } catch (e) {
+                console.error(e)
+            }
+        }
+    )
+    .help('h')
+    .alias('h', 'help')
+    .argv
+

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "devDependencies": {
     "cross-env": "^7.0.3",
     "jest": "^29.5.0",
-    "jest-fetch-mock": "^3.0.3"
+    "jest-fetch-mock": "^3.0.3",
+    "yargs": "^17.7.2"
   }
 }

--- a/parser/gdrive.js
+++ b/parser/gdrive.js
@@ -13,13 +13,11 @@ const keyPath = "credentials.json";
 
 const getCredentials = () => {
   if (process.env.GCLOUD_CREDENTIALS) {
-    console.info("Using Google credentials from GCLOUD_CREDENTIALS");
     return JSON.parse(process.env.GCLOUD_CREDENTIALS);
+  } else {
+    const data = fs.readFileSync(keyPath, "utf8");
+    return JSON.parse(data);
   }
-
-  console.info("Using Google credentials from credentials.json file");
-  const data = fs.readFileSync(keyPath, "utf8");
-  return JSON.parse(data);
 };
 
 const authenticate = async () => {


### PR DESCRIPTION
Adds a pair of CLI tools inside `devtools.js` which we can use to quickly get
the JSON representation of a doc, or the markdown representation of that JSON,
invoking as little of the rest of the system as possible for easy debugging.

Get help with `node devtools.js -h`