### PR TITLE
Remove unwanted vertical tabulations

### DIFF
--- a/parser/parser.js
+++ b/parser/parser.js
@@ -309,7 +309,8 @@ export const parsetextRun = ({ textStyle, content }) => {
       text = escapeHtml(text);
     }
   }
-  return prefix + text + suffix;
+
+  return (prefix + text + suffix).replace(/\u000B/g, "\n");
 };
 
 export const parserichLink = ({ richLinkProperties: { title, uri } }) => {


### PR DESCRIPTION
Sometimes in GDocs a user inserts a special type of line break that gets stored as a UTF-8 \u000B character, a vertical tabulation. In old times, this would feed the paper through some fixed number of lines without moving the head, and that functionality kind of survives into the modern era and produces weird behavior. This commit just replaces them all with newlines, which removes some unwanted weirdness in the markdown output.