### PR TITLE
Determine correct bullet points when calling parseParagraph

### DIFF
--- a/parser/__tests__/parser.test.js
+++ b/parser/__tests__/parser.test.js
@@ -356,7 +356,7 @@ describe("parseParagraph", () => {
       ...paragraph,
       bullet: { nestingLevel: 1, listId: "list-id" },
     };
-    documentContext.orderedList=1;
+    documentContext.orderedList = 1;
     documentContext.lists["list-id"].listProperties.nestingLevels[1].glyphType =
       "DECIMAL";
     const result = parseParagraph(documentContext)(listItem);

--- a/parser/__tests__/parser.test.js
+++ b/parser/__tests__/parser.test.js
@@ -4,7 +4,7 @@ import {
   parseDoc,
   fetchExternalContent,
   getTag,
-  parseParagraph,
+  makeParser,
   parsetextRun,
   parserichLink,
   parseinlineObjectElement,
@@ -308,7 +308,7 @@ describe("parseParagraph", () => {
       ],
       paragraphStyle: { namedStyleType: "NORMAL_TEXT" },
     };
-    const result = parseParagraph(documentContext, [paragraph])(paragraph);
+    const result = makeParser(documentContext, [paragraph])(paragraph);
     expect(result).toEqual("");
   });
 
@@ -325,12 +325,12 @@ describe("parseParagraph", () => {
       ],
       paragraphStyle: { namedStyleType: "NORMAL_TEXT" },
     };
-    const result = parseParagraph(documentContext, [paragraph])(paragraph);
+    const result = makeParser(documentContext, [paragraph])(paragraph);
     expect(result).toEqual("");
   });
 
   it("should return a plain paragraph without any formatting", () => {
-    const result = parseParagraph(documentContext, [paragraph])(paragraph);
+    const result = makeParser(documentContext, [paragraph])(paragraph);
     expect(result).toEqual("Hello, world!");
   });
 
@@ -339,7 +339,7 @@ describe("parseParagraph", () => {
       ...paragraph,
       paragraphStyle: { namedStyleType: "HEADING_1" },
     };
-    const result = parseParagraph(documentContext, [heading])(heading);
+    const result = makeParser(documentContext, [heading])(heading);
     expect(result).toEqual("# Hello, world!");
   });
 
@@ -349,7 +349,7 @@ describe("parseParagraph", () => {
       paragraphStyle: { namedStyleType: "HEADING_1" },
       bullet: { nestingLevel: 1, listId: "list-id" },
     };
-    const result = parseParagraph(documentContext, [heading])(heading);
+    const result = makeParser(documentContext, [heading])(heading);
     expect(result).toEqual("    - # Hello, world!");
   });
 
@@ -358,7 +358,7 @@ describe("parseParagraph", () => {
       ...paragraph,
       bullet: { nestingLevel: 1, listId: "list-id" },
     };
-    const result = parseParagraph(documentContext, [listItem])(listItem);
+    const result = makeParser(documentContext, [listItem])(listItem);
     expect(result).toEqual("    - Hello, world!");
   });
 
@@ -377,7 +377,7 @@ describe("parseParagraph", () => {
         },
       },
     };
-    const result = parseParagraph(context, [listItem])(listItem);
+    const result = makeParser(context, [listItem])(listItem);
     expect(result).toEqual("1. Hello, world!");
   });
 
@@ -403,7 +403,7 @@ describe("parseParagraph", () => {
         },
       },
     };
-    const parseWithContext = parseParagraph(context, paragraphs);
+    const parseWithContext = makeParser(context, paragraphs);
     const result1 = parseWithContext(paragraphs[0]);
     expect(result1).toEqual("1. Hello, world!");
     const result2 = parseWithContext(paragraphs[1]);
@@ -434,7 +434,7 @@ describe("parseParagraph", () => {
         "list-id-1": decimalList,
       },
     };
-    const parseWithContext = parseParagraph(context, paragraphs);
+    const parseWithContext = makeParser(context, paragraphs);
     const result1 = parseWithContext(paragraphs[0]);
     expect(result1).toEqual("1. Hello, world!");
     const result2 = parseWithContext(paragraphs[1]);
@@ -466,7 +466,7 @@ describe("parseParagraph", () => {
         },
       },
     };
-    const parseWithContext = parseParagraph(context, paragraphs);
+    const parseWithContext = makeParser(context, paragraphs);
     const result1 = parseWithContext(paragraphs[0]);
     expect(result1).toEqual("1. Hello, world!");
     const result2 = parseWithContext(paragraphs[1]);

--- a/parser/__tests__/parser.test.js
+++ b/parser/__tests__/parser.test.js
@@ -408,6 +408,41 @@ describe("parseParagraph", () => {
     const result2 = parseParagraph(context, paragraphs)(paragraphs[1]);
     expect(result2).toEqual("2. Hello, world!");
   });
+
+  it("should parse a list with a nested item", () => {
+    const paragraphCount = 2;
+    const paragraphs = [];
+    for (let i = 0; i < paragraphCount; i++) {
+      const runCount = 2;
+      const paragraph = getParagraph(i * runCount + 1, runCount);
+      const listItem = {
+        ...paragraph,
+        bullet: { listId: "list-id" },
+      };
+      if (i >= 1) {
+        listItem.bullet.nestingLevel = i
+      }
+      paragraphs.push(listItem);
+    }
+    const context = {
+      ...documentContext,
+      lists: {
+        "list-id": {
+          listProperties: {
+            nestingLevels: [
+              { glyphType: "DECIMAL" },
+              { glyphType: "DECIMAL" }
+            ],
+          },
+        },
+      },
+    };
+    const result1 = parseParagraph(context, paragraphs)(paragraphs[0]);
+    expect(result1).toEqual("1. Hello, world!");
+    const result2 = parseParagraph(context, paragraphs)(paragraphs[1]);
+    const nestingSpacer = "    "; 
+    expect(result2).toEqual(nestingSpacer + "1. Hello, world!");
+  });
 });
 
 describe("parseDoc", () => {

--- a/parser/__tests__/parser.test.js
+++ b/parser/__tests__/parser.test.js
@@ -409,7 +409,7 @@ describe("parseParagraph", () => {
     const result2 = parseWithContext(paragraphs[1]);
     expect(result2).toEqual("2. Hello, world!");
   });
-  
+
   it("should parse multiple lists", () => {
     const paragraphCount = 2;
     const paragraphs = [];
@@ -452,7 +452,7 @@ describe("parseParagraph", () => {
         bullet: { listId: "list-id" },
       };
       if (i >= 1) {
-        listItem.bullet.nestingLevel = i
+        listItem.bullet.nestingLevel = i;
       }
       paragraphs.push(listItem);
     }
@@ -461,10 +461,7 @@ describe("parseParagraph", () => {
       lists: {
         "list-id": {
           listProperties: {
-            nestingLevels: [
-              { glyphType: "DECIMAL" },
-              { glyphType: "DECIMAL" }
-            ],
+            nestingLevels: [{ glyphType: "DECIMAL" }, { glyphType: "DECIMAL" }],
           },
         },
       },
@@ -473,7 +470,7 @@ describe("parseParagraph", () => {
     const result1 = parseWithContext(paragraphs[0]);
     expect(result1).toEqual("1. Hello, world!");
     const result2 = parseWithContext(paragraphs[1]);
-    const nestingSpacer = "    "; 
+    const nestingSpacer = "    ";
     expect(result2).toEqual(nestingSpacer + "1. Hello, world!");
   });
 });

--- a/parser/__tests__/parser.test.js
+++ b/parser/__tests__/parser.test.js
@@ -302,19 +302,18 @@ describe("parseParagraph", () => {
   };
 
   it("should handle empty paragraphs", () => {
-    const paragraph = {
+    const result = parseParagraph(documentContext)({
       elements: [
         { textRun: { content: "  \n \n " } },
         { textRun: { content: "" } },
       ],
       paragraphStyle: { namedStyleType: "NORMAL_TEXT" },
-    };
-    const result = parseParagraph(documentContext, [paragraph])(paragraph);
+    });
     expect(result).toEqual("");
   });
 
   it("should paragraphs that are suggestions", () => {
-    const paragraph = {
+    const result = parseParagraph(documentContext)({
       elements: [
         {
           textRun: {
@@ -325,8 +324,7 @@ describe("parseParagraph", () => {
         { textRun: { content: "As is this", suggestedInsertionIds: ["2"] } },
       ],
       paragraphStyle: { namedStyleType: "NORMAL_TEXT" },
-    };
-    const result = parseParagraph(documentContext)(paragraph);
+    });
     expect(result).toEqual("");
   });
 

--- a/parser/__tests__/parser.test.js
+++ b/parser/__tests__/parser.test.js
@@ -356,6 +356,7 @@ describe("parseParagraph", () => {
       ...paragraph,
       bullet: { nestingLevel: 1, listId: "list-id" },
     };
+    documentContext.orderedList=1;
     documentContext.lists["list-id"].listProperties.nestingLevels[1].glyphType =
       "DECIMAL";
     const result = parseParagraph(documentContext)(listItem);

--- a/parser/__tests__/parser.test.js
+++ b/parser/__tests__/parser.test.js
@@ -281,6 +281,9 @@ describe("parseParagraph", () => {
         },
       },
     },
+    orderedList: {
+      "list-id": 1,
+    },
   };
 
   const paragraph = {
@@ -338,6 +341,7 @@ describe("parseParagraph", () => {
       paragraphStyle: { namedStyleType: "HEADING_1" },
       bullet: { nestingLevel: 1, listId: "list-id" },
     };
+    documentContext.orderedList["list-id"] = 1;
     const result = parseParagraph(documentContext)(heading);
     expect(result).toEqual("    - # Hello, world!");
   });
@@ -356,7 +360,7 @@ describe("parseParagraph", () => {
       ...paragraph,
       bullet: { nestingLevel: 1, listId: "list-id" },
     };
-    documentContext.orderedList = 1;
+    documentContext.orderedList["list-id"] = 1;
     documentContext.lists["list-id"].listProperties.nestingLevels[1].glyphType =
       "DECIMAL";
     const result = parseParagraph(documentContext)(listItem);

--- a/parser/__tests__/parser.test.js
+++ b/parser/__tests__/parser.test.js
@@ -403,9 +403,10 @@ describe("parseParagraph", () => {
         },
       },
     };
-    const result1 = parseParagraph(context, paragraphs)(paragraphs[0]);
+    const parseWithContext = parseParagraph(context, paragraphs);
+    const result1 = parseWithContext(paragraphs[0]);
     expect(result1).toEqual("1. Hello, world!");
-    const result2 = parseParagraph(context, paragraphs)(paragraphs[1]);
+    const result2 = parseWithContext(paragraphs[1]);
     expect(result2).toEqual("2. Hello, world!");
   });
 
@@ -437,9 +438,10 @@ describe("parseParagraph", () => {
         },
       },
     };
-    const result1 = parseParagraph(context, paragraphs)(paragraphs[0]);
+    const parseWithContext = parseParagraph(context, paragraphs);
+    const result1 = parseWithContext(paragraphs[0]);
     expect(result1).toEqual("1. Hello, world!");
-    const result2 = parseParagraph(context, paragraphs)(paragraphs[1]);
+    const result2 = parseWithContext(paragraphs[1]);
     const nestingSpacer = "    "; 
     expect(result2).toEqual(nestingSpacer + "1. Hello, world!");
   });

--- a/parser/__tests__/parser.test.js
+++ b/parser/__tests__/parser.test.js
@@ -281,9 +281,6 @@ describe("parseParagraph", () => {
         },
       },
     },
-    orderedList: {
-      "list-id": 1,
-    },
   };
 
   const paragraph = {
@@ -341,7 +338,6 @@ describe("parseParagraph", () => {
       paragraphStyle: { namedStyleType: "HEADING_1" },
       bullet: { nestingLevel: 1, listId: "list-id" },
     };
-    documentContext.orderedList["list-id"] = 1;
     const result = parseParagraph(documentContext)(heading);
     expect(result).toEqual("    - # Hello, world!");
   });

--- a/parser/__tests__/parser.test.js
+++ b/parser/__tests__/parser.test.js
@@ -283,19 +283,22 @@ describe("parseParagraph", () => {
     },
   };
 
-  const paragraph = {
-    elements: [
-      {
-        startIndex: 1,
-        textRun: { content: "Hello, " },
-      },
-      {
-        startIndex: 2,
-        textRun: { content: "world!" },
-      },
-    ],
-    paragraphStyle: { namedStyleType: "NORMAL_TEXT" },
+  const getParagraph = (startIndex, runCount) => {
+    const elements = [];
+    for (let i = 0; i < runCount; i++) {
+      elements.push({
+        startIndex: startIndex + i,
+        textRun: {
+          content: i % 2 == 0 ? "Hello, " : "world!",
+        },
+      });
+    }
+    return {
+      elements,
+      paragraphStyle: { namedStyleType: "NORMAL_TEXT" },
+    };
   };
+  const paragraph = getParagraph(1, 2);
 
   it("should handle empty paragraphs", () => {
     const paragraph = {
@@ -376,6 +379,34 @@ describe("parseParagraph", () => {
     };
     const result = parseParagraph(context, [listItem])(listItem);
     expect(result).toEqual("1. Hello, world!");
+  });
+
+  it("should parse a list with several items", () => {
+    const paragraphCount = 2;
+    const paragraphs = [];
+    for (let i = 0; i < paragraphCount; i++) {
+      const runCount = 2;
+      const paragraph = getParagraph(i * runCount + 1, runCount);
+      const listItem = {
+        ...paragraph,
+        bullet: { listId: "list-id" },
+      };
+      paragraphs.push(listItem);
+    }
+    const context = {
+      ...documentContext,
+      lists: {
+        "list-id": {
+          listProperties: {
+            nestingLevels: [{ glyphType: "DECIMAL" }],
+          },
+        },
+      },
+    };
+    const result1 = parseParagraph(context, paragraphs)(paragraphs[0]);
+    expect(result1).toEqual("1. Hello, world!");
+    const result2 = parseParagraph(context, paragraphs)(paragraphs[1]);
+    expect(result2).toEqual("2. Hello, world!");
   });
 });
 

--- a/parser/__tests__/parser.test.js
+++ b/parser/__tests__/parser.test.js
@@ -409,6 +409,37 @@ describe("parseParagraph", () => {
     const result2 = parseWithContext(paragraphs[1]);
     expect(result2).toEqual("2. Hello, world!");
   });
+  
+  it("should parse multiple lists", () => {
+    const paragraphCount = 2;
+    const paragraphs = [];
+    for (let i = 0; i < paragraphCount; i++) {
+      const runCount = 2;
+      const paragraph = getParagraph(i * runCount + 1, runCount);
+      const listItem = {
+        ...paragraph,
+        bullet: { listId: "list-id-" + i },
+      };
+      paragraphs.push(listItem);
+    }
+    const decimalList = {
+      listProperties: {
+        nestingLevels: [{ glyphType: "DECIMAL" }],
+      },
+    };
+    const context = {
+      ...documentContext,
+      lists: {
+        "list-id-0": decimalList,
+        "list-id-1": decimalList,
+      },
+    };
+    const parseWithContext = parseParagraph(context, paragraphs);
+    const result1 = parseWithContext(paragraphs[0]);
+    expect(result1).toEqual("1. Hello, world!");
+    const result2 = parseWithContext(paragraphs[1]);
+    expect(result2).toEqual("1. Hello, world!");
+  });
 
   it("should parse a list with a nested item", () => {
     const paragraphCount = 2;

--- a/parser/__tests__/parser.test.js
+++ b/parser/__tests__/parser.test.js
@@ -297,11 +297,6 @@ describe("parseParagraph", () => {
     paragraphStyle: { namedStyleType: "NORMAL_TEXT" },
   };
 
-  const setupParserAndParse = (paragraph, context = documentContext) => {
-    const allParagraphs = [paragraph];
-    return parseParagraph(context, allParagraphs)(paragraph);
-  };
-
   it("should handle empty paragraphs", () => {
     const paragraph = {
       elements: [
@@ -310,7 +305,7 @@ describe("parseParagraph", () => {
       ],
       paragraphStyle: { namedStyleType: "NORMAL_TEXT" },
     };
-    const result = setupParserAndParse(paragraph);
+    const result = parseParagraph(documentContext, [paragraph])(paragraph);
     expect(result).toEqual("");
   });
 
@@ -327,12 +322,12 @@ describe("parseParagraph", () => {
       ],
       paragraphStyle: { namedStyleType: "NORMAL_TEXT" },
     };
-    const result = setupParserAndParse(paragraph);
+    const result = parseParagraph(documentContext, [paragraph])(paragraph);
     expect(result).toEqual("");
   });
 
   it("should return a plain paragraph without any formatting", () => {
-    const result = setupParserAndParse(paragraph);
+    const result = parseParagraph(documentContext, [paragraph])(paragraph);
     expect(result).toEqual("Hello, world!");
   });
 
@@ -341,7 +336,7 @@ describe("parseParagraph", () => {
       ...paragraph,
       paragraphStyle: { namedStyleType: "HEADING_1" },
     };
-    const result = setupParserAndParse(heading);
+    const result = parseParagraph(documentContext, [heading])(heading);
     expect(result).toEqual("# Hello, world!");
   });
 
@@ -351,7 +346,7 @@ describe("parseParagraph", () => {
       paragraphStyle: { namedStyleType: "HEADING_1" },
       bullet: { nestingLevel: 1, listId: "list-id" },
     };
-    const result = setupParserAndParse(heading);
+    const result = parseParagraph(documentContext, [heading])(heading);
     expect(result).toEqual("    - # Hello, world!");
   });
 
@@ -360,7 +355,7 @@ describe("parseParagraph", () => {
       ...paragraph,
       bullet: { nestingLevel: 1, listId: "list-id" },
     };
-    const result = setupParserAndParse(listItem);
+    const result = parseParagraph(documentContext, [listItem])(listItem);
     expect(result).toEqual("    - Hello, world!");
   });
 
@@ -371,9 +366,6 @@ describe("parseParagraph", () => {
     };
     const context = {
       ...documentContext,
-      orderedList: {
-        "list-id": 1,
-      },
       lists: {
         "list-id": {
           listProperties: {
@@ -382,7 +374,7 @@ describe("parseParagraph", () => {
         },
       },
     };
-    const result = setupParserAndParse(listItem, context);
+    const result = parseParagraph(context, [listItem])(listItem);
     expect(result).toEqual("1. Hello, world!");
   });
 });

--- a/parser/parser.js
+++ b/parser/parser.js
@@ -305,6 +305,13 @@ export const parseParagraph = (documentContext) => (paragraph) => {
   }
 };
 
+/**
+ * The order numbers for paragraph bullets are stored to then be used in the actual parsing.
+ * This is done separately from the parsing because it must be done on the paragraphs in order.
+ * Once the bullet orders are determined then further parsing could be done out of order.
+ * @param {*} paragraphs an array of paragraphs where the list items are in the desired order
+ * @returns order number getter function
+ */
 export const makeBulletOrderMap = (paragraphs) => {
   // Using the startIndex of the first element of the paragraph
   // Assuming that each paragraph has at least one element
@@ -313,9 +320,6 @@ export const makeBulletOrderMap = (paragraphs) => {
     return firstElement.startIndex;
   };
 
-  // The order numbers for paragraph bullets are stored to then be used in the actual parsing
-  // This is done separately from the parsing because it must be done on the paragraphs in order
-  // Once the bullet orders are determined then further parsing could be done out of order
   const bulletOrderNumbers = new Map();
   const listBulletCounters = new Map();
   paragraphs.forEach((paragraph) => {

--- a/parser/parser.js
+++ b/parser/parser.js
@@ -253,15 +253,15 @@ export const parseParagraph = (documentContext, allParagraphs) => {
     const { elements, ...paragraphContext } = paragraph;
     const { bullet: pb } = paragraphContext;
     if (!pb) return;
-  
+
     const listCounter = listBulletCounters.get(pb.listId) || new Map();
     listBulletCounters.set(pb.listId, listCounter);
-  
+
     // Each nesting level should have separate count
     const nestingLevel = pb.nestingLevel || 0;
     const paragraphOrderNum = (listCounter.get(nestingLevel) || 0) + 1;
     listCounter.set(nestingLevel, paragraphOrderNum);
-  
+
     const paragraphId = paragraphIdGenerator(paragraph);
     if (bulletOrderNumbers.has(paragraphId)) {
       throw new Error("ParagraphId should be unique for each paragraph");

--- a/parser/parser.js
+++ b/parser/parser.js
@@ -94,7 +94,7 @@ export const parseDoc = async (doc, answer) => {
     inlineObjects: doc.inlineObjects,
     lists: doc.lists || {},
     suggestions: new Map(), // Accumulators for the count and total text length of all suggestions
-    orderedList:1,
+    orderedList: 1,
   };
   const { paragraphs, relatedAnswerDocIDs, alternativePhrasings, glossary } =
     extractDocParts(doc);
@@ -265,7 +265,7 @@ export const parseParagraph = (documentContext) => (paragraph) => {
     const listID = pb.listId;
     const list = documentContext.lists[listID];
     const currentLevel = list.listProperties.nestingLevels[nestingLevel];
-    const orderedList = documentContext.orderedList
+    const orderedList = documentContext.orderedList;
 
     // This check is ugly as sin, but necessary because GDocs doesn't actually clearly say "this is an [un]ordered list" anywhere
     // I think this is because internally, all lists are ordered and it just only sometimes uses glyphs which represent that
@@ -274,8 +274,7 @@ export const parseParagraph = (documentContext) => (paragraph) => {
       currentLevel.hasOwnProperty("glyphType") &&
       currentLevel.glyphType !== "GLYPH_TYPE_UNSPECIFIED";
 
-
-    itemMarker = isOrdered ? (orderedList+". "||"1. ") : "- ";
+    itemMarker = isOrdered ? orderedList + ". " || "1. " : "- ";
     leadingSpace = new Array(nestingLevel).fill("    ").join("");
     documentContext.orderedList++;
     return (

--- a/parser/parser.js
+++ b/parser/parser.js
@@ -251,25 +251,22 @@ export const parseParagraph = (documentContext, allParagraphs) => {
   const listBulletCounters = new Map();
   allParagraphs.forEach((paragraph) => {
     const { elements, ...paragraphContext } = paragraph;
-    if (paragraphContext.bullet) {
-      const pb = paragraphContext.bullet;
-      const listId = pb.listId;
-      if (!listBulletCounters.has(listId)) {
-        listBulletCounters.set(listId, new Map());
-      }
-      const listCounter = listBulletCounters.get(listId);
-      const nestingLevel = pb.nestingLevel || 0;
-      if (!listCounter.has(nestingLevel)) {
-        listCounter.set(nestingLevel, 0);
-      }
-      const paragraphOrderNum = listCounter.get(nestingLevel) + 1;
-      listCounter.set(nestingLevel, paragraphOrderNum);
-      const paragraphId = paragraphIdGenerator(paragraph);
-      if (bulletOrderNumbers.has(paragraphId)) {
-        throw new Error("ParagraphId should be unique for each paragraph");
-      }
-      bulletOrderNumbers.set(paragraphId, paragraphOrderNum);
+    const { bullet: pb } = paragraphContext;
+    if (!pb) return;
+  
+    const listCounter = listBulletCounters.get(pb.listId) || new Map();
+    listBulletCounters.set(pb.listId, listCounter);
+  
+    // Each nesting level should have separate count
+    const nestingLevel = pb.nestingLevel || 0;
+    const paragraphOrderNum = (listCounter.get(nestingLevel) || 0) + 1;
+    listCounter.set(nestingLevel, paragraphOrderNum);
+  
+    const paragraphId = paragraphIdGenerator(paragraph);
+    if (bulletOrderNumbers.has(paragraphId)) {
+      throw new Error("ParagraphId should be unique for each paragraph");
     }
+    bulletOrderNumbers.set(paragraphId, paragraphOrderNum);
   });
 
   return (paragraph) => {

--- a/parser/parser.js
+++ b/parser/parser.js
@@ -260,9 +260,12 @@ export const parseParagraph = (documentContext, allParagraphs) => {
         listBulletCounter.set(listId, 0);
       }
       const paragraphOrderNum = listBulletCounter.get(listId) + 1;
-      const paragraphId = paragraphIdGenerator(paragraph);
-      bulletOrderNumbers.set(paragraphId, paragraphOrderNum);
       listBulletCounter.set(listId, paragraphOrderNum);
+      const paragraphId = paragraphIdGenerator(paragraph);
+      if (bulletOrderNumbers.has(paragraphId)) {
+        throw new Error("ParagraphId should be unique for each paragraph");
+      }
+      bulletOrderNumbers.set(paragraphId, paragraphOrderNum);
     }
   });
 

--- a/parser/parser.js
+++ b/parser/parser.js
@@ -297,6 +297,11 @@ export const parseParagraph = (documentContext, allParagraphs) => {
       const listID = pb.listId;
       const list = documentContext.lists[listID];
       const currentLevel = list.listProperties.nestingLevels[nestingLevel];
+      if (!currentLevel) {
+        throw new Error(
+          "Level information should be available for all nesting levels. Input json must be incorrect"
+        );
+      }
 
       // This check is ugly as sin, but necessary because GDocs doesn't actually clearly say "this is an [un]ordered list" anywhere
       // I think this is because internally, all lists are ordered and it just only sometimes uses glyphs which represent that

--- a/parser/parser.js
+++ b/parser/parser.js
@@ -105,9 +105,9 @@ export const parseDoc = async (doc, answer) => {
     return { md: tagContent, relatedAnswerDocIDs, alternativePhrasings };
   }
 
-  const paragrapherParser = parseParagraph(documentContext);
-  const body = paragraphs.map(paragrapherParser).join("\n\n");
+  const body = paragraphs.map(parseParagraph(documentContext)).join("\n\n");
   const footnotes = extractFootnotes(documentContext, doc);
+
   const md = body + "\n\n" + footnotes;
 
   // Take the maximum of each suggestion's insertions and deletions

--- a/parser/parser.js
+++ b/parser/parser.js
@@ -94,6 +94,7 @@ export const parseDoc = async (doc, answer) => {
     inlineObjects: doc.inlineObjects,
     lists: doc.lists || {},
     suggestions: new Map(), // Accumulators for the count and total text length of all suggestions
+    orderedList:1,
   };
   const { paragraphs, relatedAnswerDocIDs, alternativePhrasings, glossary } =
     extractDocParts(doc);
@@ -105,7 +106,6 @@ export const parseDoc = async (doc, answer) => {
   }
 
   const body = paragraphs.map(parseParagraph(documentContext)).join("\n\n");
-
   const footnotes = extractFootnotes(documentContext, doc);
 
   const md = body + "\n\n" + footnotes;
@@ -265,6 +265,7 @@ export const parseParagraph = (documentContext) => (paragraph) => {
     const listID = pb.listId;
     const list = documentContext.lists[listID];
     const currentLevel = list.listProperties.nestingLevels[nestingLevel];
+    const orderedList = documentContext.orderedList
 
     // This check is ugly as sin, but necessary because GDocs doesn't actually clearly say "this is an [un]ordered list" anywhere
     // I think this is because internally, all lists are ordered and it just only sometimes uses glyphs which represent that
@@ -273,12 +274,10 @@ export const parseParagraph = (documentContext) => (paragraph) => {
       currentLevel.hasOwnProperty("glyphType") &&
       currentLevel.glyphType !== "GLYPH_TYPE_UNSPECIFIED";
 
-    // Please forgive me for always using 1. as the sequence number on list items
-    // It's sorta hard to count them properly so I'm depending on markdown renderers doing the heavy lifting for me.
-    // Which, in fairness, they're supposed to.
-    itemMarker = isOrdered ? "1. " : "- ";
-    leadingSpace = new Array(nestingLevel).fill("    ").join("");
 
+    itemMarker = isOrdered ? (orderedList+". "||"1. ") : "- ";
+    leadingSpace = new Array(nestingLevel).fill("    ").join("");
+    documentContext.orderedList++;
     return (
       leadingSpace +
       itemMarker +

--- a/parser/parser.js
+++ b/parser/parser.js
@@ -248,19 +248,22 @@ export const parseParagraph = (documentContext, allParagraphs) => {
   // This is done separately from the parsing because it must be done on the paragraphs in order
   // Once the bullet orders are determined then further parsing could be done out of order
   const bulletOrderNumbers = new Map();
-  const listBulletCounter = new Map();
+  const listBulletCounters = new Map();
   allParagraphs.forEach((paragraph) => {
     const { elements, ...paragraphContext } = paragraph;
     if (paragraphContext.bullet) {
       const pb = paragraphContext.bullet;
-      // TODO: Check if nesting needs to be considered
-      // const nestingLevel = pb.nestingLevel || 0;
       const listId = pb.listId;
-      if (!listBulletCounter.has(listId)) {
-        listBulletCounter.set(listId, 0);
+      if (!listBulletCounters.has(listId)) {
+        listBulletCounters.set(listId, new Map());
       }
-      const paragraphOrderNum = listBulletCounter.get(listId) + 1;
-      listBulletCounter.set(listId, paragraphOrderNum);
+      const listCounter = listBulletCounters.get(listId);
+      const nestingLevel = pb.nestingLevel || 0;
+      if (!listCounter.has(nestingLevel)) {
+        listCounter.set(nestingLevel, 0);
+      }
+      const paragraphOrderNum = listCounter.get(nestingLevel) + 1;
+      listCounter.set(nestingLevel, paragraphOrderNum);
       const paragraphId = paragraphIdGenerator(paragraph);
       if (bulletOrderNumbers.has(paragraphId)) {
         throw new Error("ParagraphId should be unique for each paragraph");


### PR DESCRIPTION
This PR works to address https://github.com/StampyAI/GDocsRelatedThings/issues/60 and https://github.com/StampyAI/stampy-ui/issues/352.
This PR is building off of #58, but the approach is to cache the paragraph order when creating the document context, rather than having a side-effect in parseParagraph (e.g. mutating the `documentContext`)

TODO:
- [x] Add tests for the various cases described here: https://github.com/StampyAI/GDocsRelatedThings/pull/58#discussion_r1449185234 (though it may be better to do this in a separate PR)