### PR TITLE
Update link matching regex

### DIFF
--- a/parser/main.js
+++ b/parser/main.js
@@ -151,7 +151,7 @@ export const replaceGdocLinks = (md, allAnswers) =>
   allAnswers.reduce((acc, answer) => {
     const status = answer[codaColumnIDs.status];
     const regex = new RegExp(
-      `\\[(.*?)\\]\\(\\s*?https://docs.google.com/document/(u/)?(0/)?d/${answer.docID}[^)]*?\\)`,
+      `\\[([^\]]*?)\\]\\(\\s*?https://docs.google.com/document/(u/)?(0/)?d/${answer.docID}[^)]*?\\)`,
       "g"
     );
 


### PR DESCRIPTION
Issues with parsing links due to recent refactors. They seem to stem from greedy ] parsing, I'm surprised these issues show up but I'm not sure how to find the original data the parser is receiving so I'm limited on how I can test.

![closing_brackets_gdocs](https://github.com/user-attachments/assets/fc385c8d-d334-4fa2-a7f7-f65f0221e668)
![closing_brackets](https://github.com/user-attachments/assets/62fd5a2e-e7be-482a-862e-8fea387f9183)
https://aisafety.info/questions/9J1L/Alignment-research
https://docs.google.com/document/d/11y0EdW6TmkN8fvIiOsdVS_tLTzxgOBKkiNgS2lNzC6A/edit

Since this breaks the website, this is meant as a stopgap, feel free to improve it.