### PR TITLE
Fix regex for google docs

### DIFF
--- a/parser/main.js
+++ b/parser/main.js
@@ -151,7 +151,7 @@ export const replaceGdocLinks = (md, allAnswers) =>
   allAnswers.reduce((acc, answer) => {
     const status = answer[codaColumnIDs.status];
     const regex = new RegExp(
-      `\\[([^\]]*?)\\]\\(\\s*?https://docs.google.com/document/(u/)?(0/)?d/${answer.docID}[^)]*?\\)`,
+      `\\[([^\\]]*?)\\]\\(\\s*?https://docs.google.com/document/(u/)?(0/)?d/${answer.docID}[^)]*?\\)`,
       "g"
     );
 


### PR DESCRIPTION
I had not understood that string passed to _RegExp_ needed to have their \ doubled

Tested functional on question 0.