### PR TITLE
Fix whitespace parsing

### DIFF
--- a/parser/parser.js
+++ b/parser/parser.js
@@ -353,8 +353,8 @@ export const parsetextRun = ({ textStyle, content }) => {
   // Markdown doesn't handle **THIS IS SOME BOLD TEXT ** correctly so we need to move that whitespace outside of the formatting markers.
   // Though sometimes strings consisting of only spaces come, and those should be left alone.
   if (content.trim() !== "") {
-    const leadingSpaceRegex = /^ */;
-    const trailingSpaceRegex = / *$/;
+    const leadingSpaceRegex = /^\s*/u;
+    const trailingSpaceRegex = /\s*$/u;
     prefix = (content.match(leadingSpaceRegex)?.[0] || "") + prefix;
     suffix = suffix + (content.match(trailingSpaceRegex)?.[0] || "");
     text = text.trim();

--- a/parser/parser.js
+++ b/parser/parser.js
@@ -353,8 +353,8 @@ export const parsetextRun = ({ textStyle, content }) => {
   // Markdown doesn't handle **THIS IS SOME BOLD TEXT ** correctly so we need to move that whitespace outside of the formatting markers.
   // Though sometimes strings consisting of only spaces come, and those should be left alone.
   if (content.trim() !== "") {
-    const leadingSpaceRegex = /^\s*/u;
-    const trailingSpaceRegex = /\s*$/u;
+    const leadingSpaceRegex = /^\s+/u;
+    const trailingSpaceRegex = /\s+$/u;
     prefix = (content.match(leadingSpaceRegex)?.[0] || "") + prefix;
     suffix = suffix + (content.match(trailingSpaceRegex)?.[0] || "");
     text = text.trim();


### PR DESCRIPTION
See https://discord.com/channels/677546901339504640/1125883308979535922/1293256165538529302

The sentence in the Google Docs was generating a NBSP at the end of a parser text blob, and it was not properly caught by the regex.

I tested the markdown was properly generated for that sentence, I don't expect it to break in other places.