### PR TITLE
adding initial dev-server

### DIFF
--- a/dev-server.js
+++ b/dev-server.js
@@ -1,0 +1,23 @@
+import express from "express";
+import { getDocsClient, getGoogleDoc } from "./parser/gdrive.js";
+
+const app = express();
+const PORT = 3000;
+
+// NOTE: Need credentials.json file in root to query Gdocs aPI
+app.get("/doc/", async (req, res) => {
+  try {
+    const client = await getDocsClient();
+    const answer = { docID: "10g6U9SL0CBy__wCBTib7_WhB3S3aaFt7Fx1vVgCzg2I" };
+    const doc = await getGoogleDoc(answer, client);
+    const jsonString = JSON.stringify(doc, null, 2);
+    res.json(jsonString);
+  } catch (error) {
+    console.error("An error occurred:", error);
+  }
+});
+
+// Start the server
+app.listen(PORT, () => {
+  console.log(`Server is running on port ${PORT}`);
+});

--- a/package.json
+++ b/package.json
@@ -32,8 +32,10 @@
   },
   "devDependencies": {
     "cross-env": "^7.0.3",
+    "express": "^4.21.1",
     "jest": "^29.5.0",
     "jest-fetch-mock": "^3.0.3",
+    "nodemon": "^3.1.7",
     "yargs": "^17.7.2"
   }
 }


### PR DESCRIPTION
The dev-server can be run with `npx nodemon dev-server.js`

TODO:
- Update README docs to mention how to run the server