### PR TITLE
Add disclaimer to imported tags

### DIFF
--- a/parser/__tests__/parser.test.js
+++ b/parser/__tests__/parser.test.js
@@ -864,9 +864,10 @@ describe("fetchExternalContent", () => {
     ];
     fetchMock.mockResponse(JSON.stringify(mockResponse));
     const result = await fetchExternalContent(paragraphs);
-    expect(result).toEqual(
-      {"content": "This is an example LW tag content (see mockResponse)", "sourceName": "LessWrong"}
-    );
+    expect(result).toEqual({
+      content: "This is an example LW tag content (see mockResponse)",
+      sourceName: "LessWrong",
+    });
   });
 
   it("calls getEAFTag for EAF tags", async () => {
@@ -877,9 +878,10 @@ describe("fetchExternalContent", () => {
     ];
     fetchMock.mockResponse(JSON.stringify(mockResponse));
     const result = await fetchExternalContent(paragraphs);
-    expect(result).toEqual(
-      {"content": "This is an example LW tag content (see mockResponse)", "sourceName": "the EA Forum"}
-    );
+    expect(result).toEqual({
+      content: "This is an example LW tag content (see mockResponse)",
+      sourceName: "the EA Forum",
+    });
   });
 
   it("returns null for unknown tag URLs", async () => {
@@ -900,9 +902,10 @@ describe("fetchExternalContent", () => {
     ];
     fetchMock.mockResponse(JSON.stringify(mockResponse));
     const result = await fetchExternalContent(paragraphs);
-    expect(result).toEqual(
-      {"content": "This is an example LW tag content (see mockResponse)", "sourceName": "LessWrong"}
-    );
+    expect(result).toEqual({
+      content: "This is an example LW tag content (see mockResponse)",
+      sourceName: "LessWrong",
+    });
   });
 
   it("ignores comments and suggested edits", async () => {
@@ -935,9 +938,10 @@ describe("fetchExternalContent", () => {
     ];
     fetchMock.mockResponse(JSON.stringify(mockResponse));
     const result = await fetchExternalContent(paragraphs);
-    expect(result).toEqual(
-      {"content": "This is an example LW tag content (see mockResponse)", "sourceName": "LessWrong"}
-    );
+    expect(result).toEqual({
+      content: "This is an example LW tag content (see mockResponse)",
+      sourceName: "LessWrong",
+    });
   });
 });
 

--- a/parser/__tests__/parser.test.js
+++ b/parser/__tests__/parser.test.js
@@ -752,7 +752,7 @@ describe("parseDoc", () => {
     const result = await parseDoc(doc);
 
     expect(result.md).toEqual(
-      "This is an example LW tag content (see mockResponse)"
+      "<i>This text was automatically imported from a tag on LessWrong</i>\n\nThis is an example LW tag content (see mockResponse)"
     );
     expect(result.relatedAnswerDocIDs).toEqual([]);
   });
@@ -769,7 +769,7 @@ describe("parseDoc", () => {
     const result = await parseDoc(doc);
 
     expect(result.md).toEqual(
-      "This is an example LW tag content (see mockResponse)"
+      "<i>This text was automatically imported from a tag on the EA Forum</i>\n\nThis is an example LW tag content (see mockResponse)"
     );
     expect(result.relatedAnswerDocIDs).toEqual([]);
   });
@@ -789,7 +789,7 @@ describe("parseDoc", () => {
     const result = await parseDoc(doc);
 
     expect(result.md).toEqual(
-      "This is an example LW tag content (see mockResponse)"
+      "<i>This text was automatically imported from a tag on LessWrong</i>\n\nThis is an example LW tag content (see mockResponse)"
     );
     expect(result.relatedAnswerDocIDs).toEqual([]);
   });
@@ -865,7 +865,7 @@ describe("fetchExternalContent", () => {
     fetchMock.mockResponse(JSON.stringify(mockResponse));
     const result = await fetchExternalContent(paragraphs);
     expect(result).toEqual(
-      "This is an example LW tag content (see mockResponse)"
+      {"content": "This is an example LW tag content (see mockResponse)", "sourceName": "LessWrong"}
     );
   });
 
@@ -878,7 +878,7 @@ describe("fetchExternalContent", () => {
     fetchMock.mockResponse(JSON.stringify(mockResponse));
     const result = await fetchExternalContent(paragraphs);
     expect(result).toEqual(
-      "This is an example LW tag content (see mockResponse)"
+      {"content": "This is an example LW tag content (see mockResponse)", "sourceName": "the EA Forum"}
     );
   });
 
@@ -901,7 +901,7 @@ describe("fetchExternalContent", () => {
     fetchMock.mockResponse(JSON.stringify(mockResponse));
     const result = await fetchExternalContent(paragraphs);
     expect(result).toEqual(
-      "This is an example LW tag content (see mockResponse)"
+      {"content": "This is an example LW tag content (see mockResponse)", "sourceName": "LessWrong"}
     );
   });
 
@@ -936,7 +936,7 @@ describe("fetchExternalContent", () => {
     fetchMock.mockResponse(JSON.stringify(mockResponse));
     const result = await fetchExternalContent(paragraphs);
     expect(result).toEqual(
-      "This is an example LW tag content (see mockResponse)"
+      {"content": "This is an example LW tag content (see mockResponse)", "sourceName": "LessWrong"}
     );
   });
 });

--- a/parser/parser.js
+++ b/parser/parser.js
@@ -152,31 +152,28 @@ export const fetchExternalContent = async (paragraphs) => {
   const text = texts[0];
 
   const tagHandlers = [
-    [/https:\/\/(www.)?lesswrong.com\/tag\/(?<tagName>[A-z0-9_-]+)/, getLWTag],
+    [
+      /https:\/\/(www.)?lesswrong.com\/tag\/(?<tagName>[A-z0-9_-]+)/,
+      getLWTag,
+      "LessWrong",
+    ],
     [
       /https:\/\/forum.effectivealtruism.org\/topics\/(?<tagName>[A-z0-9_-]+)/,
       getEAFTag,
+      "the EA Forum",
     ],
     [
       /https:\/\/(www.)?alignmentforum.org\/tag\/(?<tagName>[A-z0-9_-]+)/,
       getAFTag,
+      "the Alignment Forum",
     ],
   ];
 
-  for (const [regex, handler] of tagHandlers) {
+  for (const [regex, handler, sourceName] of tagHandlers) {
     const match = text.match(regex);
     if (match) {
       const content = await handler(match.groups.tagName);
-      return {
-        content,
-        sourceName: text.includes("lesswrong.com")
-          ? "LessWrong"
-          : text.includes("effectivealtruism.org")
-          ? "the EA Forum"
-          : text.includes("alignmentforum.org")
-          ? "the Alignment Forum"
-          : "an external source",
-      };
+      return { content, sourceName };
     }
   }
   return null;

--- a/parser/parser.js
+++ b/parser/parser.js
@@ -103,10 +103,10 @@ export const parseDoc = async (doc, answer) => {
   const tagContent = await fetchExternalContent(paragraphs);
   if (tagContent) {
     const attributionMessage = `<i>This text was automatically imported from a tag on ${tagContent.sourceName}</i>\n\n`;
-    return { 
-      md: attributionMessage + tagContent.content, 
-      relatedAnswerDocIDs, 
-      alternativePhrasings 
+    return {
+      md: attributionMessage + tagContent.content,
+      relatedAnswerDocIDs,
+      alternativePhrasings,
     };
   }
 
@@ -169,10 +169,13 @@ export const fetchExternalContent = async (paragraphs) => {
       const content = await handler(match.groups.tagName);
       return {
         content,
-        sourceName: text.includes('lesswrong.com') ? 'LessWrong' :
-                    text.includes('effectivealtruism.org') ? 'the EA Forum' :
-                    text.includes('alignmentforum.org') ? 'the Alignment Forum' :
-                    'an external source'
+        sourceName: text.includes("lesswrong.com")
+          ? "LessWrong"
+          : text.includes("effectivealtruism.org")
+          ? "the EA Forum"
+          : text.includes("alignmentforum.org")
+          ? "the Alignment Forum"
+          : "an external source",
       };
     }
   }


### PR DESCRIPTION
To address https://github.com/StampyAI/stampy-ui/issues/842

Example output metadata:
node devtools.js md 1x9Jn8s4XcLtiP-vVA8crCCg27JdJ3TnAuL8zAMRm4sE
<i>This text was automatically imported from a tag on LessWrong</i>

**Human Values** are the things we care about, and would want an aligned superintelligence to look after and support. It is suspected that true human values are [highly complex](https://www.lesswrong.com/tag/complexity-of-value), and could be extrapolated into a wide variety of forms.
