### PR TITLE
Move "Marked for deletion" to "Removed answers"

### DIFF
--- a/parser/gdrive.js
+++ b/parser/gdrive.js
@@ -103,14 +103,20 @@ const folders = {
   "Live on site": "1feloLCiyc3XSxfaQ0L_fqVVsFMupw2JM",
   "In progress": "1U2h3Tte38EkOff9flwo6FKVZn8OhkNLW",
   Answers: "1XUTbO31BMSBBZLhwFsvPObnuMbVVd59H",
+  "Removed answers": "1EZxiJzFNcyNi-sDdJzBXOZO3HReXkIkF",
 };
 
 export const moveAnswer = async (drive, answer) => {
-  const folderName = ["Live on site", "Subsection"].includes(
-    answer[codaColumnIDs.status]
-  )
-    ? "Live on site"
-    : "In progress";
+  let folderName;
+  const status = answer[codaColumnIDs.status];
+
+  if (status === "Marked for deletion") {
+    folderName = "Removed answers";
+  } else if (status === "Live on site" || status === "Subsection") {
+    folderName = "Live on site";
+  } else {
+    folderName = "In progress";
+  }
   const folder = folders[folderName];
 
   try {


### PR DESCRIPTION
Fixes https://github.com/StampyAI/GDocsRelatedThings/issues/77

Not tested, and I did not see any appropriate unit tests, but it looks pretty straightforward.

It seems like Coda keeps track of metadata such as the status even after a row is removed. In the unlikely circumstance where we would want to move a document from "Removed answers" to e.g. "in progress", I'm not sure that running the script would not immediately dump it in "Removed answers" again. I think the issue is minor enough that we can deal with it if it comes up, but if there is an easy solution I'm open to suggestions.