### PR TITLE
Remove special parsing of grey text

### DIFF
--- a/parser/__tests__/parser.test.js
+++ b/parser/__tests__/parser.test.js
@@ -74,43 +74,6 @@ describe("parsetextRun", () => {
     expect(parsetextRun(emptyRun)).toBe("");
   });
 
-  it.each([
-    [{ red: 0.31, green: 0.31, blue: 0.31 }],
-    [{ red: 0.4, green: 0.4, blue: 0.4 }],
-    [{ red: 0.5, green: 0.5, blue: 0.5 }],
-    // Try some with a bit of variance
-    [{ red: 0.5, green: 0.491, blue: 0.501 }],
-  ])(
-    "should return empty string for grey text with rgbColor = %p",
-    (rgbColor) => {
-      const textRun = {
-        content: "bla bla bla",
-        textStyle: { foregroundColor: { color: { rgbColor } } },
-      };
-      expect(parsetextRun(textRun)).toBe("");
-    }
-  );
-
-  it.each([
-    // really dark grey or explicit black isn't removed
-    [{ red: 0.01, green: 0.01, blue: 0.01 }],
-    [{ red: 0.0, green: 0.0, blue: 0.0 }],
-    // really light grey or white isn't removed
-    [{ red: 0.99, green: 0.99, blue: 0.99 }],
-    [{ red: 1.0, green: 1.0, blue: 1.0 }],
-    // non gray is removed
-    [{ red: 0.5, green: 0.0, blue: 0.5 }],
-    [{ red: 0.1, green: 0.5, blue: 0.8 }],
-  ])(
-    "should not return empty string for non text with rgbColor = %p",
-    (rgbColor) => {
-      const textRun = {
-        content: "bla bla bla",
-        textStyle: { foregroundColor: { color: { rgbColor } } },
-      };
-      expect(parsetextRun(textRun)).toBe("bla bla bla");
-    }
-  );
 
   it("should format bold text", () => {
     const textRun = { content: "Hello World", textStyle: { bold: true } };

--- a/parser/__tests__/parser.test.js
+++ b/parser/__tests__/parser.test.js
@@ -74,7 +74,6 @@ describe("parsetextRun", () => {
     expect(parsetextRun(emptyRun)).toBe("");
   });
 
-
   it("should format bold text", () => {
     const textRun = { content: "Hello World", textStyle: { bold: true } };
     expect(parsetextRun(textRun)).toBe("**Hello World**");

--- a/parser/parser.js
+++ b/parser/parser.js
@@ -372,21 +372,8 @@ export const makeBulletOrderMap = (paragraphs) => {
   };
 };
 
-const isGrey = (textStyle) => {
-  const { red, green, blue } =
-    textStyle?.foregroundColor?.color?.rgbColor || {};
-  const tolerance = 0.01;
-  return (
-    red &&
-    red > 0.3 &&
-    red < 0.93 &&
-    Math.abs(red - blue) <= tolerance &&
-    Math.abs(red - green) <= tolerance
-  );
-};
-
 export const parsetextRun = ({ textStyle, content }) => {
-  if (content === "\n" || content.length === 0 || isGrey(textStyle)) {
+  if (content === "\n" || content.length === 0) {
     //  We add newlines into the markdown when joining all the segments up, so we don't need to keep pieces of text that are just newlines
     return "";
   }


### PR DESCRIPTION
We have comments in google now, so we don't need grey parsing. As editors, we have decided to remove this feature.

Was successfully tested with grey text.