### PR TITLE
Support page breaks and convert them to \n\n

### DIFF
--- a/parser/parser.js
+++ b/parser/parser.js
@@ -540,6 +540,8 @@ export const parseElement = (context) => (element) => {
     inlineObjectElement: parseinlineObjectElement,
     horizontalRule: parsehorizontalRule,
     table: tableParser(context),
+    // Add parsers for additional element types
+    pageBreak: () => "\n\n", // Simple parser for page breaks
   };
 
   const elementType = Object.keys(element).find(
@@ -547,6 +549,12 @@ export const parseElement = (context) => (element) => {
   );
 
   const elementContent = element[elementType];
+
+  // Add a fallback for unknown element types
+  if (!parsers[elementType]) {
+    console.warn(`Warning: Unknown element type "${elementType}" - ignoring`);
+    return "";
+  }
 
   let md = parsers[elementType](elementContent, context);
 


### PR DESCRIPTION
Parser crashed on [one document](https://docs.google.com/document/d/1Fb0sfwRplhW1-syww2z9ciKyNCPiN9GikfEkfMwKUBE/edit?tab=t.0) with page breaks, which resulted in no output.

Claude suggested a bunch of defensive parsing of other potential features, (e.g. table of contents), but I'd rather add them as they become necessary.