### PR TITLE
Improve parsing of newlines

### DIFF
--- a/devtools.js
+++ b/devtools.js
@@ -3,6 +3,7 @@ import { hideBin } from "yargs/helpers";
 
 import { getDocsClient } from "./parser/gdrive.js";
 import { parseDoc } from "./parser/parser.js";
+import { compressMarkdown } from "./parser/utils.js";
 
 const getDocJSON = async (documentId) => {
   const docsClient = await getDocsClient();
@@ -40,7 +41,13 @@ yargs(hideBin(process.argv))
     }) => {
       try {
         const docJSON = await getDocJSON(documentId);
-        console.log((await parseDoc(docJSON)).md);
+        // Get the markdown content
+        let md = (await parseDoc(docJSON)).md;
+        
+        // Apply the same fixes from compressMarkdown in utils.js
+        md = compressMarkdown(md);
+        
+        console.log(md);
       } catch (e) {
         if (e.code === 404) {
           console.error("Invalid doc ID");

--- a/devtools.js
+++ b/devtools.js
@@ -43,10 +43,10 @@ yargs(hideBin(process.argv))
         const docJSON = await getDocJSON(documentId);
         // Get the markdown content
         let md = (await parseDoc(docJSON)).md;
-        
+
         // Apply the same fixes from compressMarkdown in utils.js
         md = compressMarkdown(md);
-        
+
         console.log(md);
       } catch (e) {
         if (e.code === 404) {

--- a/parser/__tests__/parser.test.js
+++ b/parser/__tests__/parser.test.js
@@ -501,6 +501,57 @@ describe("parseDoc", () => {
   beforeEach(() => {
     fetchMock.resetMocks();
   });
+  
+  it("ensures proper spacing between paragraphs and list items", async () => {
+    // Create a simple doc with a list - giving unique startIndex values for each paragraph element
+    const doc = {
+      body: {
+        content: [
+          {
+            paragraph: {
+              elements: [{ startIndex: 100, textRun: { content: "Regular paragraph" } }],
+            }
+          },
+          {
+            paragraph: {
+              elements: [{ startIndex: 200, textRun: { content: "First bullet" } }],
+              bullet: { listId: "list1", nestingLevel: 0 }
+            }
+          },
+          {
+            paragraph: {
+              elements: [{ startIndex: 300, textRun: { content: "Second bullet" } }],
+              bullet: { listId: "list1", nestingLevel: 0 }
+            }
+          },
+          {
+            paragraph: {
+              elements: [{ startIndex: 400, textRun: { content: "Another paragraph" } }],
+            }
+          },
+        ],
+      },
+      lists: {
+        list1: {
+          listProperties: {
+            nestingLevels: [{ glyphSymbol: "-" }]
+          }
+        }
+      },
+      footnotes: {},
+    };
+    
+    // Process the document
+    const result = await parseDoc(doc);
+    
+    // Verify bullet points have correct markup
+    expect(result.md).toContain("- First bullet");
+    expect(result.md).toContain("- Second bullet");
+    
+    // Verify paragraphs and lists have double newlines
+    expect(result.md).toContain("Regular paragraph\n\n- First bullet");
+    expect(result.md).toContain("Second bullet\n\nAnother paragraph");
+  });
 
   it("parses a document without footnotes or related answers", async () => {
     const doc = {

--- a/parser/__tests__/parser.test.js
+++ b/parser/__tests__/parser.test.js
@@ -501,7 +501,7 @@ describe("parseDoc", () => {
   beforeEach(() => {
     fetchMock.resetMocks();
   });
-  
+
   it("ensures proper spacing between paragraphs and list items", async () => {
     // Create a simple doc with a list - giving unique startIndex values for each paragraph element
     const doc = {
@@ -509,45 +509,53 @@ describe("parseDoc", () => {
         content: [
           {
             paragraph: {
-              elements: [{ startIndex: 100, textRun: { content: "Regular paragraph" } }],
-            }
+              elements: [
+                { startIndex: 100, textRun: { content: "Regular paragraph" } },
+              ],
+            },
           },
           {
             paragraph: {
-              elements: [{ startIndex: 200, textRun: { content: "First bullet" } }],
-              bullet: { listId: "list1", nestingLevel: 0 }
-            }
+              elements: [
+                { startIndex: 200, textRun: { content: "First bullet" } },
+              ],
+              bullet: { listId: "list1", nestingLevel: 0 },
+            },
           },
           {
             paragraph: {
-              elements: [{ startIndex: 300, textRun: { content: "Second bullet" } }],
-              bullet: { listId: "list1", nestingLevel: 0 }
-            }
+              elements: [
+                { startIndex: 300, textRun: { content: "Second bullet" } },
+              ],
+              bullet: { listId: "list1", nestingLevel: 0 },
+            },
           },
           {
             paragraph: {
-              elements: [{ startIndex: 400, textRun: { content: "Another paragraph" } }],
-            }
+              elements: [
+                { startIndex: 400, textRun: { content: "Another paragraph" } },
+              ],
+            },
           },
         ],
       },
       lists: {
         list1: {
           listProperties: {
-            nestingLevels: [{ glyphSymbol: "-" }]
-          }
-        }
+            nestingLevels: [{ glyphSymbol: "-" }],
+          },
+        },
       },
       footnotes: {},
     };
-    
+
     // Process the document
     const result = await parseDoc(doc);
-    
+
     // Verify bullet points have correct markup
     expect(result.md).toContain("- First bullet");
     expect(result.md).toContain("- Second bullet");
-    
+
     // Verify paragraphs and lists have double newlines
     expect(result.md).toContain("Regular paragraph\n\n- First bullet");
     expect(result.md).toContain("Second bullet\n\nAnother paragraph");

--- a/parser/parser.js
+++ b/parser/parser.js
@@ -110,7 +110,9 @@ export const parseDoc = async (doc, answer) => {
     };
   }
 
-  const body = paragraphs.map(parseParagraph(documentContext)).join("\n\n");
+  // Process paragraphs and join with double newlines for spacing
+  const processedParagraphs = paragraphs.map(parseParagraph(documentContext)).filter(Boolean);
+  const body = processedParagraphs.join('\n\n');
   const footnotes = extractFootnotes(documentContext, doc);
 
   const md = body + "\n\n" + footnotes;

--- a/parser/parser.js
+++ b/parser/parser.js
@@ -111,8 +111,10 @@ export const parseDoc = async (doc, answer) => {
   }
 
   // Process paragraphs and join with double newlines for spacing
-  const processedParagraphs = paragraphs.map(parseParagraph(documentContext)).filter(Boolean);
-  const body = processedParagraphs.join('\n\n');
+  const processedParagraphs = paragraphs
+    .map(parseParagraph(documentContext))
+    .filter(Boolean);
+  const body = processedParagraphs.join("\n\n");
   const footnotes = extractFootnotes(documentContext, doc);
 
   const md = body + "\n\n" + footnotes;

--- a/parser/utils.js
+++ b/parser/utils.js
@@ -16,28 +16,28 @@ export const compressMarkdown = (md) => {
     );
     currentSize = ret.length;
   }
-  
+
   // First step: Remove all trailing whitespace from lines
   ret = ret.replace(/[ \t]+$/gm, "");
-  
+
   // Post-process to ensure no consecutive empty lines (fixes display issues)
   ret = ret.replace(/\n{2,}/g, "\n\n");
-  
+
   // Fix unordered list spacing - normalize all items to single lines
   // This pattern handles any number of consecutive bullet points with any amount of spacing between them
   ret = ret.replace(/^(\s*-[^\n]+\n)(?:\s*\n)*(?=\s*-)/gm, "$1");
-  
+
   // Fix ordered list spacing - normalize all items to single lines
   // Similar pattern for numbered lists
   ret = ret.replace(/^(\s*\d+\.[^\n]+\n)(?:\s*\n)*(?=\s*\d+\.)/gm, "$1");
-  
+
   // Ensure proper spacing between list items and paragraphs
   ret = ret.replace(/^(\s*-[^\n]+?\n)([^-\s])/gm, "$1\n$2");
   ret = ret.replace(/^(\s*\d+\.[^\n]+?\n)([^\d\s])/gm, "$1\n$2");
-  
+
   // Ensure no trailing newlines
   ret = ret.replace(/\n+$/, "");
-  
+
   currentSize = ret.length;
 
   return ret;

--- a/parser/utils.js
+++ b/parser/utils.js
@@ -16,9 +16,28 @@ export const compressMarkdown = (md) => {
     );
     currentSize = ret.length;
   }
-
-  // Also clear out excessive newlines, we get a lot of those
-  ret = ret.replaceAll(/\n\n(\n+)/g, "\n\n");
+  
+  // First step: Remove all trailing whitespace from lines
+  ret = ret.replace(/[ \t]+$/gm, "");
+  
+  // Post-process to ensure no consecutive empty lines (fixes display issues)
+  ret = ret.replace(/\n{2,}/g, "\n\n");
+  
+  // Fix unordered list spacing - normalize all items to single lines
+  // This pattern handles any number of consecutive bullet points with any amount of spacing between them
+  ret = ret.replace(/^(\s*-[^\n]+\n)(?:\s*\n)*(?=\s*-)/gm, "$1");
+  
+  // Fix ordered list spacing - normalize all items to single lines
+  // Similar pattern for numbered lists
+  ret = ret.replace(/^(\s*\d+\.[^\n]+\n)(?:\s*\n)*(?=\s*\d+\.)/gm, "$1");
+  
+  // Ensure proper spacing between list items and paragraphs
+  ret = ret.replace(/^(\s*-[^\n]+?\n)([^-\s])/gm, "$1\n$2");
+  ret = ret.replace(/^(\s*\d+\.[^\n]+?\n)([^\d\s])/gm, "$1\n$2");
+  
+  // Ensure no trailing newlines
+  ret = ret.replace(/\n+$/, "");
+  
   currentSize = ret.length;
 
   return ret;


### PR DESCRIPTION
Attempt to fix https://github.com/StampyAI/stampy-ui/issues/613, won't know if it fully works until it is merged since it's hard to confirm on the website what a certain parsed document would look like. I expect we will need follow-ups, but at least this cleans up the ridiculous number of unneeded newlines in the parsed document.

To see the difference, compare [before](https://github.com/user-attachments/files/19839074/before.txt) and [after](https://github.com/user-attachments/files/19839076/after.txt) on [this document](https://docs.google.com/document/d/1iXjZsLVIZ1uv7Lypty8FrnqKJje2dV8xIVYmTCfQ9aA/edit?tab=t.0)

[The Diff](https://github.com/user-attachments/files/19839048/diff-main.txt)

I ended up moving some parsing from devtools.js to utils.js to ensure consistent parsing between main.js and devtools.js.

The number of regexes to remove whitespace/newlines seemed excessive, but I tried a lot of other options unsuccessfully. Claude justifies them so:
  1. Step 1: Remove trailing whitespace ✅ NECESSARY
    - Essential for fixing the trailing whitespace issue mentioned
    - Without this step, we still see      space characters after bullet points
  2. Step 2: Normalize newlines ✅ NECESSARY
    - This replaces multiple consecutive newlines with just two
    - Helps establish a baseline for consistent spacing
    - Note: In the test "with just normalization", we already see improvement, but it's not enough
  3. Step 3: Fix bullet point spacing ✅ NECESSARY
    - This makes bullet points join with single newlines
    - Without this, even with normalized newlines, there's still a blank line between each bullet point
  4. Step 4: Fix numbered list spacing ✅ NECESSARY
    - This makes numbered list items join with single newlines
    - Without this, numbered lists would still have blank lines between items
    - The test clearly shows this is needed for numbered lists
  5. Step 5: Fix list-paragraph spacing ✅ NECESSARY
    - Although not explicitly tested here, this ensures we have a blank line between list items and paragraphs
    - Without this, there would be no space between a list and the next paragraph
    - This is standard Markdown formatting
    
Feel free to push back against any of these.
