### PR TITLE
Print logging when Coda returns HTML instead of JSON

### DIFF
--- a/bin/importGlossary.js
+++ b/bin/importGlossary.js
@@ -419,5 +419,24 @@ async function main() {
 // Run the main function
 main().catch((error) => {
   console.error("Error in glossary import process:", error);
+
+  // Special handling for JSON parse errors that might indicate HTML responses
+  if (
+    error instanceof SyntaxError &&
+    error.message.includes("Unexpected token")
+  ) {
+    console.error(
+      "Received non-JSON response. This might be an HTML error page."
+    );
+
+    // If we have the raw response text, log it for diagnosis
+    if (error.rawHtml) {
+      console.error("HTML response received:");
+      console.error("----------------------------------------");
+      console.error(error.rawHtml.substring(0, 2000)); // Log first 2000 chars to avoid excessive output
+      console.error("----------------------------------------");
+    }
+  }
+
   process.exit(1);
 });


### PR DESCRIPTION
There is this intermittent [issue](https://github.com/StampyAI/GDocsRelatedThings/actions/runs/14586508909/job/40912917733) where Coda will return HTML instead of JSON. I simply want to print the HTML answer to understand what it is returning, we can diagnose after that.

My plan is to eventually revert this logging when we have figured out the root cause.