### PR TITLE
Enable retry for all API calls

### DIFF
--- a/parser/cloudflare.js
+++ b/parser/cloudflare.js
@@ -1,16 +1,20 @@
 import { randomUUID } from "crypto";
+import { withRetry } from "./utils.js";
 
 const sendRequest = (endpoint, method, body) =>
-  fetch(
-    `https://api.cloudflare.com/client/v4/accounts/${process.env.CLOUDFLARE_ACCOUNT_ID}/images/${endpoint}`,
-    {
-      method,
-      headers: {
-        Authorization: `Bearer ${process.env.CLOUDFLARE_API_TOKEN}`,
-      },
-      body,
-    }
-  ).then((res) => res.json());
+  withRetry(async () => {
+    const response = await fetch(
+      `https://api.cloudflare.com/client/v4/accounts/${process.env.CLOUDFLARE_ACCOUNT_ID}/images/${endpoint}`,
+      {
+        method,
+        headers: {
+          Authorization: `Bearer ${process.env.CLOUDFLARE_API_TOKEN}`,
+        },
+        body,
+      }
+    );
+    return response.json();
+  }, `Cloudflare API ${method} to /images/${endpoint.split("?")[0]}`);
 
 const uploadImage = async (url, metadata) => {
   const formData = new FormData();

--- a/parser/coda.js
+++ b/parser/coda.js
@@ -1,18 +1,21 @@
 import { tableURL, codaColumnIDs, glossaryTableURL } from "./constants.js";
+import { withRetry } from "./utils.js";
 
 export const getDocIDFromLink = (docLink) =>
   docLink.match(/https:\/\/\w+.google.com\/(\w+\/)+(?<docID>[_-\w]{25,}).*/)
     ?.groups?.docID || null;
 
 const codaRequest = async (url, options = { headers: {} }) =>
-  fetch(encodeURI(url), {
-    timeout: 5000,
-    ...options,
-    headers: {
-      ...options.headers,
-      Authorization: `Bearer ${process.env.CODA_TOKEN}`,
-    },
-  });
+  withRetry(async () => {
+    return fetch(encodeURI(url), {
+      timeout: 5000,
+      ...options,
+      headers: {
+        ...options.headers,
+        Authorization: `Bearer ${process.env.CODA_TOKEN}`,
+      },
+    });
+  }, `Coda API request to ${url.split("?")[0]}`); // Log URL without query params
 
 const getRows = async (tableURL) => {
   let queryURL = `${tableURL}/rows`;


### PR DESCRIPTION
Follow-up to https://github.com/StampyAI/GDocsRelatedThings/pull/87

There have been [a few failures](https://github.com/StampyAI/GDocsRelatedThings/actions?query=is%3Afailure) recently, and I believe they are all linked to Coda temporary errors.

Instead of just retrying on Coda errors, I decided to retry on all API call errors with certain codes.

I could not test this properly since I can't generate the errors on demand.