### PR TITLE
Update parser for new LW GraphQL format

### DIFF
--- a/parser/__tests__/parser.test.js
+++ b/parser/__tests__/parser.test.js
@@ -36,13 +36,15 @@ describe("getTag", () => {
   it("Footnotes are handled correctly", async () => {
     const mockResponse = {
       data: {
-        tag: {
-          result: {
-            description: {
-              markdown: `This is an example LW tag content (see mockResponse) ^[\\[123\\]](#fn0f5x8s34vee)^.
+        tags: {
+          results: [
+            {
+              description: {
+                markdown: `This is an example LW tag content (see mockResponse) ^[\\[123\\]](#fn0f5x8s34vee)^.
 123.  ^**[^](#fnref0f5x8s34vee)**^\n    \n    And this is a footnote`,
+              },
             },
-          },
+          ],
         },
       },
     };
@@ -752,12 +754,14 @@ describe("parseDoc", () => {
 
   const mockResponse = {
     data: {
-      tag: {
-        result: {
-          description: {
-            markdown: `This is an example LW tag content (see mockResponse)`,
+      tags: {
+        results: [
+          {
+            description: {
+              markdown: `This is an example LW tag content (see mockResponse)`,
+            },
           },
-        },
+        ],
       },
     },
   };
@@ -825,12 +829,14 @@ describe("fetchExternalContent", () => {
 
   const mockResponse = {
     data: {
-      tag: {
-        result: {
-          description: {
-            markdown: `This is an example LW tag content (see mockResponse)`,
+      tags: {
+        results: [
+          {
+            description: {
+              markdown: `This is an example LW tag content (see mockResponse)`,
+            },
           },
-        },
+        ],
       },
     },
   };


### PR DESCRIPTION
Fix https://github.com/StampyAI/stampy-ui/issues/944

The GraphQL structure on LW seems to have changed recently. I know nothing about GraphQL, I attempted to make the minimum changes that make it fetch the data correctly.

```
node devtools.js md 1BaskThfo9CP8O687uKis9hYVOIGFtGafdlXQNVXi8i0
<i>This text was automatically imported from [a tag on LessWrong](https://www.lesswrong.com/w/narrow-ai
).</i>

A **Narrow AI** is capable of operating only in a relatively limited domain, such as chess or driving, rather than capable of learning a broad range of tasks like a human or an [Artificial General Intelligence](https://www.lesswrong.com/tag/artificial-general-intelligence). Narrow vs General is not a perfectly binary classification: there are degrees of generality with, for example, large language models having a fairly large degree of generality (as the domain of text is large) without being as general as a human, and we may eventually build systems that are significantly more general than humans.
```