### PR TITLE
Add needsProcessing and move logic to Coda

### DIFF
--- a/parser/constants.js
+++ b/parser/constants.js
@@ -31,6 +31,7 @@ export const codaColumnIDs = {
   alternativePhrasings: "c-bLWz7lnXHG",
   tags: "c-fW9FG_MXY0",
   banners: "c-xODpP0JOAn",
+  needsProcessing: "c-u2DRC1IgsQ",
 
   glossaryWord: "c-QdLiDUKLm0",
   glossaryRichText: "c-KXNjnKWLkC",

--- a/parser/main.js
+++ b/parser/main.js
@@ -276,8 +276,7 @@ const parseAllAnswerDocs = async () => {
       const lastDocEditDate = new Date(answer[codaColumnIDs.docLastEdited]);
       const status = answer[codaColumnIDs.status];
       const needsUpdate =
-        lastIngestDateString === "" ||
-        lastDocEditDate > lastIngestDate ||
+        answer[codaColumnIDs.needsProcessing] === true ||
         answer.answerName === "Example with all the formatting" ||
         Boolean(process.env.PARSE_ALL);
       return !["Withdrawn", "Uncategorized"].includes(status) && needsUpdate;


### PR DESCRIPTION
We keep having issues with moved documents that don't get updated properly.

I created a "Needs Processing" column in Coda, which offloads some processing from this script.

I confirmed that the column and script work when changing status

TODO: Wait for confirmation it works with changed text.