### PR TITLE
Update headers for GraphQL

### DIFF
--- a/parser/__tests__/parser.test.js
+++ b/parser/__tests__/parser.test.js
@@ -57,13 +57,13 @@ describe("getTag", () => {
     );
   });
 
-  it("should return empty string for invalid input", async () => {
+  it("should return error message for invalid input", async () => {
     const mockResponse = { data: {} };
     fetchMock.mockResponse(JSON.stringify(mockResponse));
 
     const result = await getTag("https://bla.bla", "test");
 
-    expect(result).toEqual("");
+    expect(result).toEqual("Failed to fetch tag");
   });
 });
 

--- a/parser/parser.js
+++ b/parser/parser.js
@@ -186,6 +186,10 @@ export const fetchExternalContent = async (paragraphs) => {
 const LWGraphQLQuery = async (host, query) => {
   const result = await fetch(encodeURI(`${host}/graphql?query=${query}`), {
     timeout: 5000,
+    headers: {
+      "Content-Type": "application/json",
+      "x-apollo-operation-name": "GetTag",
+    },
   });
   return await result.json();
 };
@@ -229,11 +233,16 @@ export const getTag = async (host, tagName) => {
     }`;
 
     const contents = await LWGraphQLQuery(host, htmlQuery);
-    return contents?.data?.tags?.results?.[0]?.htmlWithContributorAnnotations;
+    return (
+      contents?.data?.tags?.results?.[0]?.htmlWithContributorAnnotations ||
+      "Failed to fetch tag"
+    );
   }
 
   // For newer version tags, use the markdown content
-  const md = asMd?.data?.tags?.results?.[0]?.description?.markdown || "";
+  const md =
+    asMd?.data?.tags?.results?.[0]?.description?.markdown ||
+    "Failed to fetch tag";
 
   // EAF mostly gives us valid markdown but their citations are in a really weird format
   // It's unlike anything I can see in the reference material I'm using to write our markdown


### PR DESCRIPTION
Fix https://github.com/StampyAI/stampy-ui/issues/944

LW's GraphQL requirements keep changing. Added a header, works now.

I also added a fallback message to avoid an empty page.