### PR TITLE
Add GH action to update glossary images

### DIFF
--- a/.github/workflows/update_glossary_images.yaml
+++ b/.github/workflows/update_glossary_images.yaml
@@ -1,0 +1,36 @@
+name: Update glossary images
+
+on:
+  workflow_dispatch:
+    permissions:
+      roles:
+        # A special role to limit who can deploy stuff - see https://github.com/orgs/StampyAI/teams/deployers
+        - StampyAI/deployers
+
+env:
+  CODA_TOKEN: ${{ secrets.CODA_TOKEN }}
+  GCLOUD_CREDENTIALS: ${{ secrets.GCLOUD_CREDENTIALS }}
+  DISCORD_ERROR: ${{ secrets.DISCORD_ERROR }}
+  DISCORD_FEED: ${{ secrets.DISCORD_FEED }}
+  CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+  CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+
+jobs:
+  run-parser:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: '20.x'
+
+    - name: Install dependencies
+      run: npm install
+
+    - name: Run the parser
+      run: node bin/importGlossary.js --update-images


### PR DESCRIPTION
Fix https://github.com/StampyAI/stampy-ui/issues/979

I did not have the Cloudflare API key so running `node bin/importGlossary.js --update-images` locally replaced the images with unaccessible URLs such as `https://lh7-rt.googleusercontent.com/docsz/AD_4nXdN1F67niiFjI3FefLLOkSlMg2G2hV1U6eoIAi4-oRADFN6BZwgx8RED0DzE9JDDhSNs7_mMJUCdE_sryzhfDsqKBj0rW0-bflXQ3UkyH5bjP7fzZlLGWyJ0dr4-VkVVoylUO-39aNtUxh0R-qyzOtzjAjA?key=bAQ25iUYSGeTTSCs4NC6Vg`

I expect running it in Github will solve the issue. It won't be run automatically since the --update-images forces replacement of a bunch of images that have not actually changed.