### PR TITLE
Fix parsing of tables

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "google-auth-library": "^8.7.0",
     "googleapis": "^105.0.0",
     "html-entities": "^2.4.0",
+    "markdown-table": "^3.0.4",
     "node-fetch": "^3.3.1",
     "prettier": "^2.8.8"
   },


### PR DESCRIPTION
fix https://github.com/StampyAI/stampy-ui/issues/586

```
node devtools.js md 1U9aqgveqQUuHtA4t8gTmLIncSBMZ2v3K9eSTEQ-0_dQ

Table Below

| This  | Is  | A       |
| ----- | --- | ------- |
| Table | For | Testing |

Table above
```

Not tested what this looks like on site, since there is no way to directly test a markdown output in stampy-ui. The number of tables on site is low, if it breaks we will fix it in stampy-ui.