### PR TITLE
Split out processing of Glossary Table explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,9 @@ For the below, a useful google doc for testing is the
 It has document id `10g6U9SL0CBy__wCBTib7_WhB3S3aaFt7Fx1vVgCzg2I`.
 
 ## Fetch and Parse a Single Document
+
 The `devtool.js` script can be run using node.js to either fetch the JSON or the parsed markdown for a google doc. See the script for parameter details.
 
 ## Git diff changes
+
 The `dev-output-diff.sh` bash script can be run to do a git diff of document to visualize how changes in a feature branch will affect the parsed markdown.


### PR DESCRIPTION
Fix crashes such as https://github.com/StampyAI/GDocsRelatedThings/actions/runs/17809394384/job/50629155293

Previous implementation was minimal
`-      .slice(1)
-      .map((row) => Object.fromEntries(row.map((val, i) => [header[i], val])));
`
It broke when we fixed tables in general.

Now a bit more explicit, no longer relying on parseElement.