### PR TITLE
Improve space efficiency of markdown tables

### DIFF
--- a/parser/__tests__/parser.test.js
+++ b/parser/__tests__/parser.test.js
@@ -1315,7 +1315,7 @@ describe("tableParser", () => {
     expect(result).toContain("| Header 1");
     expect(result).toContain("| Header 2");
     expect(result).toContain("| Header 3");
-    expect(result).toContain("| -----------"); // Should have separator line
+    expect(result).toContain("| - |"); // Should have separator line (compact format)
     expect(result).toContain("| Row 1 Col 1");
     expect(result).toContain("| Row 2 Col 1");
   });

--- a/parser/parser.js
+++ b/parser/parser.js
@@ -646,7 +646,8 @@ export const tableParser = (context) => {
     }
 
     // Use markdown-table to generate properly formatted markdown table
-    return markdownTable(rawRows);
+    // alignDelimiters: false avoids padding columns to equal width, saving significant space
+    return markdownTable(rawRows, { alignDelimiters: false });
   };
 };
 


### PR DESCRIPTION
Remove excessive whitespace when generating MD tables, effectively reduces size by ~70% for sparse tables.

This is necessary to allow pushing large tables to Coda.