### PR TITLE
Improve non-JSON error logging

### DIFF
--- a/parser/__tests__/parser.test.js
+++ b/parser/__tests__/parser.test.js
@@ -51,7 +51,9 @@ describe("getTag", () => {
         },
       },
     };
-    fetchMock.mockResponse(JSON.stringify(mockResponse));
+    fetchMock.mockResponse(JSON.stringify(mockResponse), {
+      headers: { "content-type": "application/json" },
+    });
 
     const result = await getTag("https://bla.bla", "test");
 
@@ -62,7 +64,9 @@ describe("getTag", () => {
 
   it("should return error message for invalid input", async () => {
     const mockResponse = { data: {} };
-    fetchMock.mockResponse(JSON.stringify(mockResponse));
+    fetchMock.mockResponse(JSON.stringify(mockResponse), {
+      headers: { "content-type": "application/json" },
+    });
 
     const result = await getTag("https://bla.bla", "test");
 
@@ -988,7 +992,9 @@ describe("parseDoc", () => {
       },
     };
 
-    fetchMock.mockResponse(JSON.stringify(mockResponse));
+    fetchMock.mockResponse(JSON.stringify(mockResponse), {
+      headers: { "content-type": "application/json" },
+    });
     const result = await parseDoc(doc);
 
     expect(result.md).toEqual(
@@ -1006,7 +1012,9 @@ describe("parseDoc", () => {
         ],
       },
     };
-    fetchMock.mockResponse(JSON.stringify(mockResponse));
+    fetchMock.mockResponse(JSON.stringify(mockResponse), {
+      headers: { "content-type": "application/json" },
+    });
     const result = await parseDoc(doc);
 
     expect(result.md).toEqual(
@@ -1097,7 +1105,9 @@ describe("fetchExternalContent", () => {
       makeText("").paragraph,
       { elements: [{}] },
     ];
-    fetchMock.mockResponse(JSON.stringify(mockResponse));
+    fetchMock.mockResponse(JSON.stringify(mockResponse), {
+      headers: { "content-type": "application/json" },
+    });
     const result = await fetchExternalContent(paragraphs);
     expect(result).toEqual({
       content: "This is an example LW tag content (see mockResponse)",
@@ -1134,7 +1144,9 @@ describe("fetchExternalContent", () => {
         paragraphStyle: { namedStyleType: "NORMAL_TEXT" },
       },
     ];
-    fetchMock.mockResponse(JSON.stringify(mockResponse));
+    fetchMock.mockResponse(JSON.stringify(mockResponse), {
+      headers: { "content-type": "application/json" },
+    });
     const result = await fetchExternalContent(paragraphs);
     expect(result).toEqual({
       content: "This is an example LW tag content (see mockResponse)",

--- a/parser/cloudflare.js
+++ b/parser/cloudflare.js
@@ -17,8 +17,22 @@ const sendRequest = (endpoint, method, body) =>
       );
 
       if (!response.ok) {
+        const responseText = await response.text();
         const error = new Error(`Cloudflare API error: ${response.statusText}`);
         error.status = response.status;
+        error.rawHtml = responseText;
+        throw error;
+      }
+
+      // Check for non-JSON responses
+      const contentType = response.headers.get("content-type");
+      if (contentType && !contentType.includes("application/json")) {
+        const responseText = await response.text();
+        const error = new Error(
+          `Cloudflare API returned non-JSON response: ${contentType}`
+        );
+        error.status = response.status;
+        error.rawHtml = responseText;
         throw error;
       }
 

--- a/parser/coda.js
+++ b/parser/coda.js
@@ -24,10 +24,13 @@ const codaRequest = async (url, options = { headers: {} }) =>
       contentType &&
       !contentType.includes("application/json")
     ) {
+      // Read the response body to capture error details for debugging
+      const responseText = await response.text();
       const error = new Error(
         `Coda API returned non-JSON response: ${contentType}`
       );
       error.status = response.status;
+      error.rawHtml = responseText;
       throw error;
     }
 

--- a/parser/main.js
+++ b/parser/main.js
@@ -137,11 +137,23 @@ const saveAnswer = async (
     );
     return false;
   } else {
-    const error = await response.json();
-    await logError(
-      `HTTP ${response.status} response from Coda for "${answer.answerName}: ${error.message}"`,
-      answer
-    );
+    // Check if response is JSON before parsing
+    const contentType = response.headers.get("content-type");
+    if (contentType && !contentType.includes("application/json")) {
+      const responseText = await response.text();
+      await logError(
+        `HTTP ${response.status} non-JSON response from Coda for "${
+          answer.answerName
+        }": ${responseText.substring(0, 300)}`,
+        answer
+      );
+    } else {
+      const error = await response.json();
+      await logError(
+        `HTTP ${response.status} response from Coda for "${answer.answerName}: ${error.message}"`,
+        answer
+      );
+    }
     return false;
   }
   return true;

--- a/parser/parser.js
+++ b/parser/parser.js
@@ -247,6 +247,20 @@ const LWGraphQLQuery = async (host, query) => {
     headers,
     body: JSON.stringify({ query }),
   });
+
+  // Check for non-JSON responses (e.g., HTML error pages)
+  const contentType = result.headers.get("content-type");
+  if (contentType && !contentType.includes("application/json")) {
+    const responseText = await result.text();
+    console.error(
+      `GraphQL request to ${host} returned non-JSON response: ${contentType}`
+    );
+    console.error(
+      `Response (first 500 chars): ${responseText.substring(0, 500)}`
+    );
+    throw new Error(`GraphQL returned non-JSON response: ${contentType}`);
+  }
+
   return await result.json();
 };
 

--- a/parser/utils.js
+++ b/parser/utils.js
@@ -197,7 +197,7 @@ export const withRetry = async (fn, operationName, options = {}) => {
         );
 
         // Log more details about the error for debugging
-        if (error instanceof SyntaxError && error.rawHtml) {
+        if (error.rawHtml) {
           console.error("Failed with HTML response (first 500 chars):");
           console.error(error.rawHtml.substring(0, 500));
         }
@@ -213,6 +213,12 @@ export const withRetry = async (fn, operationName, options = {}) => {
         }s...`
       );
       console.log(`Error: ${error.message}`);
+      // Log HTML snippet on first retry only to avoid log spam
+      if (error.rawHtml && retryCount === 1) {
+        console.log(
+          `HTML response (first 300 chars): ${error.rawHtml.substring(0, 300)}`
+        );
+      }
 
       // Wait before retrying
       await new Promise((resolve) => setTimeout(resolve, delay));


### PR DESCRIPTION
Increase verbosity for errors such as
https://github.com/StampyAI/GDocsRelatedThings/actions/runs/21188064459/job/60947813739#step:5:18

Also preemptively increased verbosity for other possible non-json errors